### PR TITLE
SDK-Update and new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ java -jar s3pt.jar [options...]
  --http               : use http instead of https (default: false)
  --keepAlive          : use TCP keep alive (default: false)
  --keyFileName VAL    : name of file with object keys
- --operation VAL      : operation (default: UPLOAD)
+ --operation VAL      : CLEAR_BUCKET|CREATE_BUCKET|CREATE_KEY_FILE|RANDOM_GET|RANDOM_READ
+                        |RANDOM_READ_FIRST_BYTE|RANDOM_READ_METADATA|UPLOAD_AND_READ|UPLOAD (default: UPLOAD)
+ --prefix VAL         : optional prefix for "folder" within bucket
+ --region VAL         : explicit region, e.g. us-west-1
  --secretKey VAL      : secret access key; also possible to set AWS_SECRET_KEY
                         in environment
  --signerOverride VAL : override the S3 signer (e.g. 'S3Signer' or

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>s3pt</artifactId>
     <name>S3 Performance Test</name>
     <packaging>jar</packaging>
-    <version>0.6-SNAPSHOT</version>
+    <version>0.7-SNAPSHOT</version>
     <description>A tool to test the performance of Amazon S3 or S3-compatible object storage systems like Ceph with radosgw
     </description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <commons-lang3.version>3.4</commons-lang3.version>
         <commons-math3.version>3.6</commons-math3.version>
         <commons-io.version>2.5</commons-io.version>
-        <aws-java-sdk.version>1.11.31</aws-java-sdk.version>
+        <aws-java-sdk.version>1.11.642</aws-java-sdk.version>
         <!-- plugin versions -->
         <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>

--- a/src/main/java/de/jeha/s3pt/Main.java
+++ b/src/main/java/de/jeha/s3pt/Main.java
@@ -50,7 +50,8 @@ public class Main {
     @Option(name = "--prefix", usage = "optional prefix for \"folder\" within bucket")
     private String prefix = null;
 
-    @Option(name = "--operation", usage = "operation")
+    @Option(name = "--operation", usage = "CLEAR_BUCKET|CREATE_BUCKET|CREATE_KEY_FILE|RANDOM_GET|RANDOM_READ|"
+            + "RANDOM_READ_FIRST_BYTE|RANDOM_READ_METADATA|UPLOAD_AND_READ|UPLOAD")
     private String operation = Operation.UPLOAD.name();
 
     @Option(name = "--http", usage = "use http instead of https")

--- a/src/main/java/de/jeha/s3pt/Main.java
+++ b/src/main/java/de/jeha/s3pt/Main.java
@@ -41,6 +41,9 @@ public class Main {
     @Option(name = "--endpointUrl", usage = "endpoint url")
     private String endpointUrl = DEFAULT_S3_ENDPOINT;
 
+    @Option(name = "--region", usage = "explicit region, e.g. us-west-1")
+    private String region = null;
+
     @Option(name = "--bucketName", usage = "name of bucket")
     private String bucketName = null;
 
@@ -110,6 +113,7 @@ public class Main {
                 accessKey,
                 secretKey,
                 endpointUrl,
+                region,
                 bucketName,
                 Operation.valueOf(operation),
                 threads,

--- a/src/main/java/de/jeha/s3pt/Main.java
+++ b/src/main/java/de/jeha/s3pt/Main.java
@@ -47,6 +47,9 @@ public class Main {
     @Option(name = "--bucketName", usage = "name of bucket")
     private String bucketName = null;
 
+    @Option(name = "--prefix", usage = "optional prefix for \"folder\" within bucket")
+    private String prefix = null;
+
     @Option(name = "--operation", usage = "operation")
     private String operation = Operation.UPLOAD.name();
 
@@ -115,6 +118,7 @@ public class Main {
                 endpointUrl,
                 region,
                 bucketName,
+                prefix,
                 Operation.valueOf(operation),
                 threads,
                 n,

--- a/src/main/java/de/jeha/s3pt/Operation.java
+++ b/src/main/java/de/jeha/s3pt/Operation.java
@@ -8,7 +8,9 @@ public enum Operation {
     CLEAR_BUCKET(false),
     CREATE_BUCKET(false),
     CREATE_KEY_FILE(false),
+    RANDOM_GET(true),
     RANDOM_READ(true),
+    RANDOM_READ_FIRST_BYTE(true),
     RANDOM_READ_METADATA(true),
     UPLOAD_AND_READ(true),
     UPLOAD(true);

--- a/src/main/java/de/jeha/s3pt/operations/RandomReadMetadata.java
+++ b/src/main/java/de/jeha/s3pt/operations/RandomReadMetadata.java
@@ -19,12 +19,14 @@ public class RandomReadMetadata extends AbstractOperation {
 
     private final AmazonS3 s3Client;
     private final String bucket;
+    private final String prefix;
     private final int n;
     private final String keyFileName;
 
-    public RandomReadMetadata(AmazonS3 s3Client, String bucket, int n, String keyFileName) {
+    public RandomReadMetadata(AmazonS3 s3Client, String bucket, String prefix, int n, String keyFileName) {
         this.s3Client = s3Client;
         this.bucket = bucket;
+        this.prefix = prefix;
         this.n = n;
         this.keyFileName = keyFileName;
     }
@@ -35,7 +37,7 @@ public class RandomReadMetadata extends AbstractOperation {
 
         final ObjectKeys objectKeys;
         if (keyFileName == null) {
-            objectKeys = new S3ObjectKeysDataProvider(s3Client, bucket).get();
+            objectKeys = new S3ObjectKeysDataProvider(s3Client, bucket, prefix).get();
         } else {
             objectKeys = new SingletonFileObjectKeysDataProvider(keyFileName).get();
         }
@@ -44,7 +46,7 @@ public class RandomReadMetadata extends AbstractOperation {
 
         for (int i = 0; i < n; i++) {
             final String randomKey = objectKeys.getRandom();
-            LOG.debug("Read object: {}", randomKey);
+            LOG.debug("Read object: randomKey{}", randomKey);
 
             stopWatch.reset();
             stopWatch.start();

--- a/src/main/java/de/jeha/s3pt/operations/Upload.java
+++ b/src/main/java/de/jeha/s3pt/operations/Upload.java
@@ -21,12 +21,14 @@ public class Upload extends AbstractOperation {
 
     private final AmazonS3 s3Client;
     private final String bucket;
+    private final String prefix;
     private final int n;
     private final int size;
 
-    public Upload(AmazonS3 s3Client, String bucket, int n, int size) {
+    public Upload(AmazonS3 s3Client, String bucket, String prefix, int n, int size) {
         this.s3Client = s3Client;
         this.bucket = bucket;
+        this.prefix = prefix;
         this.n = n;
         this.size = size;
     }
@@ -37,7 +39,13 @@ public class Upload extends AbstractOperation {
 
         for (int i = 0; i < n; i++) {
             final byte data[] = RandomDataGenerator.generate(size);
-            final String key = UUID.randomUUID().toString();
+            final String key;
+            if (prefix != null) {
+                key = prefix + "/" + UUID.randomUUID().toString();
+            } else {
+                key = UUID.randomUUID().toString();
+            }
+
             LOG.debug("Uploading object: {}", key);
 
             final ObjectMetadata objectMetadata = new ObjectMetadata();

--- a/src/main/java/de/jeha/s3pt/operations/data/S3ObjectKeysDataProvider.java
+++ b/src/main/java/de/jeha/s3pt/operations/data/S3ObjectKeysDataProvider.java
@@ -16,10 +16,12 @@ public class S3ObjectKeysDataProvider implements DataProvider<ObjectKeys> {
 
     private final AmazonS3 s3Client;
     private final String bucket;
+    private final String prefix;
 
-    public S3ObjectKeysDataProvider(AmazonS3 s3Client, String bucket) {
+    public S3ObjectKeysDataProvider(AmazonS3 s3Client, String bucket, String prefix) {
         this.s3Client = s3Client;
         this.bucket = bucket;
+        this.prefix = prefix;
     }
 
     @Override
@@ -27,7 +29,7 @@ public class S3ObjectKeysDataProvider implements DataProvider<ObjectKeys> {
         int objectsRead = 0;
         ObjectKeys objectKeys = new ObjectKeys();
 
-        LOG.info("Collect object keys");
+        LOG.info("Collect object keys bucket={}, prefix={}", bucket, prefix);
 
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();
@@ -37,7 +39,7 @@ public class S3ObjectKeysDataProvider implements DataProvider<ObjectKeys> {
         do {
             ObjectListing objectListing = (previousObjectListing != null)
                     ? s3Client.listNextBatchOfObjects(previousObjectListing)
-                    : s3Client.listObjects(bucket);
+                    : s3Client.listObjects(bucket, prefix);
             previousObjectListing = objectListing;
             truncated = objectListing.isTruncated();
 


### PR DESCRIPTION
This pull request contains

1. two new options (--region and --prefix)
2. two new operations (RANDOM_GET, RANDOM_READ_FIRST_BYTE)
3. an update to the latest AWS SDK including some refactoring to replace deprecated methods

I have tested the change with _AWS S3_, _minio_ and _RedHat Ceph_.

Option --region was needed get the test running against _minio_. The option --prefix is intended to place the test objects in "folders". I found it useful in my tests.

With the new SDK the existing RANDOM_READ has created warnings in each request, because the object was not read to the end. So I decided to offer 3 methods:
- RANDOM_GET is more or less like the existing RANDOM_READ
- RANDOM_READ does now a full read of the S3ObjectInputStream
- RANDOM_READ_FIRST_BYTE reads only the first 4K bytes
